### PR TITLE
Set Korean→Japanese MyMemory defaults and collapsible translation UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,49 +50,52 @@
     </header>
 
     <!-- 翻訳 UI -->
-    <section class="row">
-      <div class="card stack">
-        <div class="right">
-          <h2 style="margin-right:auto">原文入力</h2>
+    <details id="translateBox" open>
+      <summary class="btn">翻訳欄</summary>
+      <section class="row" style="margin-top:8px">
+        <div class="card stack">
           <div class="right">
-            <label class="pill">From
-              <select id="sourceLang">
-                <option value="auto">自動</option>
-                <option value="ja">日本語</option>
-                <option value="ko">韓国語</option>
-                <option value="en">英語</option>
-                <option value="zh">中国語</option>
-                <option value="de">ドイツ語</option>
-                <option value="fr">フランス語</option>
-                <option value="es">スペイン語</option>
-              </select>
-            </label>
-            <span class="muted">→</span>
-            <label class="pill">To
-              <select id="targetLang">
-                <option value="ja">日本語</option>
-                <option value="ko">韓国語</option>
-                <option value="en">英語</option>
-                <option value="zh">中国語</option>
-                <option value="de">ドイツ語</option>
-                <option value="fr">フランス語</option>
-                <option value="es">スペイン語</option>
-              </select>
-            </label>
-            <button class="btn" id="translateBtn">翻訳</button>
+            <h2 style="margin-right:auto">原文入力</h2>
+            <div class="right">
+              <label class="pill">From
+                <select id="sourceLang">
+                  <option value="auto">自動</option>
+                  <option value="ja">日本語</option>
+                  <option value="ko" selected>韓国語</option>
+                  <option value="en">英語</option>
+                  <option value="zh">中国語</option>
+                  <option value="de">ドイツ語</option>
+                  <option value="fr">フランス語</option>
+                  <option value="es">スペイン語</option>
+                </select>
+              </label>
+              <span class="muted">→</span>
+              <label class="pill">To
+                <select id="targetLang">
+                  <option value="ja">日本語</option>
+                  <option value="ko">韓国語</option>
+                  <option value="en">英語</option>
+                  <option value="zh">中国語</option>
+                  <option value="de">ドイツ語</option>
+                  <option value="fr">フランス語</option>
+                  <option value="es">スペイン語</option>
+                </select>
+              </label>
+              <button class="btn" id="translateBtn">翻訳</button>
+            </div>
           </div>
+          <textarea id="sourceText" placeholder="ここに原文を入力"></textarea>
+          <div class="small muted">自動ルビ（カタカナ）：</div>
+          <div id="rubySource" class="ruby"></div>
         </div>
-        <textarea id="sourceText" placeholder="ここに原文を入力"></textarea>
-        <div class="small muted">自動ルビ（カタカナ）：</div>
-        <div id="rubySource" class="ruby"></div>
-      </div>
-      <div class="card stack">
-        <h2>翻訳結果</h2>
-        <textarea id="translatedText" placeholder="翻訳結果がここに表示されます"></textarea>
-        <div class="small muted">自動ルビ（カタカナ）：</div>
-        <div id="rubyTranslated" class="ruby"></div>
-      </div>
-    </section>
+        <div class="card stack">
+          <h2>翻訳結果</h2>
+          <textarea id="translatedText" placeholder="翻訳結果がここに表示されます"></textarea>
+          <div class="small muted">自動ルビ（カタカナ）：</div>
+          <div id="rubyTranslated" class="ruby"></div>
+        </div>
+      </section>
+    </details>
 
     <!-- 手入力 & キーボード -->
     <section class="row" style="margin-top:16px">
@@ -141,12 +144,12 @@
         <label class="pill">Provider
           <select id="provider">
             <option value="libre">LibreTranslate</option>
-            <option value="mymemory">MyMemory</option>
+            <option value="mymemory" selected>MyMemory</option>
           </select>
         </label>
         <div></div>
       </div>
-      <div id="cfg-libre" style="display:grid;grid-template-columns:1fr 1fr;gap:8px">
+      <div id="cfg-libre" style="display:none;grid-template-columns:1fr 1fr;gap:8px">
         <label>LibreTranslate Base URL
           <input id="libreBase" type="url" placeholder="https://libretranslate.com" value="https://libretranslate.com"/>
         </label>
@@ -154,7 +157,7 @@
           <input id="libreKey" type="text" placeholder="空でOK（自己ホストや鍵不要のミラー）" />
         </label>
       </div>
-      <div id="cfg-mymemory" style="display:none;grid-template-columns:1fr 1fr;gap:8px">
+      <div id="cfg-mymemory" style="display:grid;grid-template-columns:1fr 1fr;gap:8px">
         <label>Contact Email（任意 / de パラメータ）
           <input id="mmEmail" type="email" placeholder="user@example.com（高頻度利用時に推奨）" />
         </label>


### PR DESCRIPTION
## Summary
- default translation direction to Korean → Japanese
- use MyMemory as default translation provider
- allow translation section to be collapsed

## Testing
- `npx htmlhint index.html` *(fails: 403 Forbidden to fetch package)*

------
https://chatgpt.com/codex/tasks/task_b_68a4323bc7e883259911ef911f5dff4f